### PR TITLE
Fix spec for start() and Formula's constructor

### DIFF
--- a/truesat_src/solver/data_structures.dfy
+++ b/truesat_src/solver/data_structures.dfy
@@ -1242,6 +1242,17 @@ trait DataStructures {
                 && isSatisfied(tau')
   }
 
+  predicate isSatisfiableTruthAssignment(tau : seq<Int32.t>, tau':seq<Int32.t>)
+    reads `variablesCount, `clauses, `clausesCount,
+          `clauseLength, clauseLength;
+    requires validVariablesCount();
+    requires validClauses();
+    requires validValuesTruthAssignment(tau);
+  {
+    validValuesTruthAssignment(tau')
+                && isExtendingTau(tau, tau')
+                && isSatisfied(tau')
+  }
 
   function method isUnitClause(index : Int32.t) : bool
     reads this, traceVariable, traceValue, traceDLStart, 

--- a/truesat_src/solver/formula.dfy
+++ b/truesat_src/solver/formula.dfy
@@ -11,7 +11,8 @@ class Formula extends DataStructures {
     requires InputPredicate.valid((variablesCount, clauses));
 
     ensures valid();
-
+    ensures this.variablesCount == variablesCount
+    ensures this.clauses == clauses
     ensures fresh(this.traceVariable) && fresh(this.traceValue) &&
       fresh(this.traceDLStart) && fresh(this.traceDLEnd) &&
       fresh(this.clauseLength) && fresh(this.trueLiteralsCount) &&
@@ -1630,8 +1631,8 @@ class Formula extends DataStructures {
     requires valid();
     requires !hasEmptyClause();
     requires isEmpty();
-
     ensures isSatisfiableExtend(truthAssignment[..]);
+    ensures isSatisfiableTruthAssignment(truthAssignment[..], truthAssignment[..])
   {
     assert forall i :: 0 <= i < |clauses| ==>
         trueLiteralsCount[i] > 0;

--- a/truesat_src/solver/solver.dfy
+++ b/truesat_src/solver/solver.dfy
@@ -45,6 +45,7 @@ class SATSolver {
     ensures result.SAT? ==> (
       var (variable, val) := formula.convertLVtoVI(literal, value);
       formula.isSatisfiableExtend(formula.truthAssignment[..][variable as int := val]));
+    ensures result.SAT? ==> formula.isSatisfiableTruthAssignment(old(formula.truthAssignment[..]), result.tau)
 
     ensures result.UNSAT? ==> (
       var (variable, val) := formula.convertLVtoVI(literal, value);
@@ -93,6 +94,7 @@ class SATSolver {
 
     ensures result.SAT? ==> formula.validValuesTruthAssignment(result.tau);
     ensures result.SAT? ==> formula.isSatisfiableExtend(formula.truthAssignment[..]);
+    ensures result.SAT? ==> formula.isSatisfiableTruthAssignment(old(formula.truthAssignment[..]), result.tau)
     ensures result.UNSAT? ==>
       !formula.isSatisfiableExtend(formula.truthAssignment[..]);
     ensures formula.countUnsetVariables(formula.truthAssignment[..]) ==
@@ -150,6 +152,7 @@ class SATSolver {
     ensures formula.valid();
     ensures result.SAT? ==> formula.validValuesTruthAssignment(result.tau);
     ensures result.SAT? ==> formula.isSatisfiableExtend(old(formula.truthAssignment[..]));
+    ensures result.SAT? ==> formula.isSatisfiableTruthAssignment(old(formula.truthAssignment[..]), result.tau)
     ensures result.UNSAT? ==>
       !formula.isSatisfiableExtend(old(formula.truthAssignment[..]));
   {


### PR DESCRIPTION
We thought there was specification weaknesses in Module SATSolver - method start(), and Module Formula - constructor method. We provide a strengthened spec here, and fixed the proof by exporting postconditions from lower-level methods called.
